### PR TITLE
Use override consistently silencing compiler warning

### DIFF
--- a/growth.h
+++ b/growth.h
@@ -43,7 +43,6 @@ public:
 
 
     virtual GrowthFunction* copy() { return new GrowthFunction(*this); }
-
 };
 
 
@@ -54,10 +53,10 @@ public:
 class LinearGrowth : public GrowthFunction
 {
 public:
-    virtual double getLength(double t, double r, double k, Root* root) const override { return std::min(k,r*t); } ///< @see GrowthFunction
-    virtual double getAge(double l, double r, double k, Root* root)  const override { return l/r; } ///< @see GrowthFunction
+    double getLength(double t, double r, double k, Root* root) const override { return std::min(k,r*t); } ///< @see GrowthFunction
+    double getAge(double l, double r, double k, Root* root)  const override { return l/r; } ///< @see GrowthFunction
 
-    virtual GrowthFunction* copy() { return new LinearGrowth(*this); }
+    GrowthFunction* copy() override { return new LinearGrowth(*this); }
 };
 
 
@@ -67,15 +66,15 @@ public:
 class ExponentialGrowth : public GrowthFunction
 {
 public:
-    virtual double getLength(double t, double r, double k, Root* root) const override { return k*(1-exp(-(r/k)*t)); } ///< @see GrowthFunction
-    virtual double getAge(double l, double r, double k, Root* root) const override {
+    double getLength(double t, double r, double k, Root* root) const override { return k*(1-exp(-(r/k)*t)); } ///< @see GrowthFunction
+    double getAge(double l, double r, double k, Root* root) const override {
         if (l>(0.999*k)) { // 0.999*k is reached in finite time
             l=0.999*k;
         }
         return - k/r*log(1-l/k);
     } ///< @see GrowthFunction
 
-    virtual GrowthFunction* copy() { return new ExponentialGrowth(*this); }
+    GrowthFunction* copy() override { return new ExponentialGrowth(*this); }
 };
 
 


### PR DESCRIPTION
 Also, virtual is redundant when using override