### PR TITLE
[cmake] Make Python 3 an optional dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_BUILD_TYPE Release)
 # add source directory to the include path
 include_directories(${PROJECT_SOURCE_DIR})
 
-# 
+#
 # 1. Make RootBox library
 #
 
@@ -39,22 +39,29 @@ tropism.cpp
 #
 
 # Find necessary packages for py_rootbox
-find_package(PythonLibs 3 REQUIRED)
-find_package(PythonInterp 3 REQUIRED) # creates PYTHON_VERSION_MAJOR, PYTHON_VERSION_MINOR
-include_directories( ${PYTHON_INCLUDE_DIRS} ) 
-find_package( Boost COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED )
-include_directories( ${Boost_INCLUDE_DIR} )
+find_package(PythonLibs 3)
+find_package(PythonInterp 3) # creates PYTHON_VERSION_MAJOR, PYTHON_VERSION_MINOR
 
-# make shared library for Pyhton binding
-add_library(py_rootbox SHARED PythonRootSystem.cpp 
-analysis.cpp
-ModelParameter.cpp
-Root.cpp
-RootSystem.cpp
-sdf.cpp
-tropism.cpp
-examples/Exudation/gauss_legendre.cpp)
-set_property(TARGET py_rootbox PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(py_rootbox ${Boost_LIBRARIES} )
-set_target_properties(py_rootbox PROPERTIES PREFIX "" )
+# Only build the library if Python 3 was found
+if (PythonLibs_FOUND)
+  include_directories( ${PYTHON_INCLUDE_DIRS} )
+  find_package( Boost COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED )
+  include_directories( ${Boost_INCLUDE_DIR} )
 
+  # make shared library for Pyhton binding
+  add_library(py_rootbox SHARED
+              PythonRootSystem.cpp
+              analysis.cpp
+              ModelParameter.cpp
+              Root.cpp
+              RootSystem.cpp
+              sdf.cpp
+              tropism.cpp
+              examples/Exudation/gauss_legendre.cpp)
+  set_property(TARGET py_rootbox PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_link_libraries(py_rootbox ${Boost_LIBRARIES} )
+  set_target_properties(py_rootbox PROPERTIES PREFIX "" )
+else ()
+  message(WARNING "Python 3 was not found on your system! You can only use the C++ interface of CRootBox. \
+                   Install Python 3 and rerun CMake to build the py_rootbox library.")
+endif ()


### PR DESCRIPTION
Python 3 is only needed if the Python interface is used. With this patch instead of a CMakeError
a CMakeWarning is shown recommending to install Python in order to use the Python interface.